### PR TITLE
Read base URL from BuildConfig

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
     id("kotlin-parcelize")
 }
 
+val BASE_URL: String by project
+
 android {
     namespace = "com.infomatica.inforestapp"
     compileSdk = 34
@@ -16,6 +18,8 @@ android {
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"
+
+        buildConfigField("String", "BASE_URL", "\"$BASE_URL\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -39,6 +43,7 @@ android {
     }
     buildFeatures {
         viewBinding = true
+        buildConfig = true
     }
 }
 

--- a/app/src/main/java/com/infomatica/inforestapp/core/LocalStore.kt
+++ b/app/src/main/java/com/infomatica/inforestapp/core/LocalStore.kt
@@ -1,5 +1,6 @@
 import android.content.Context
 import android.content.SharedPreferences
+import com.infomatica.inforestapp.BuildConfig
 
 object LocalStore {
     private const val PREF_NAME = "AppPreferences"
@@ -17,7 +18,7 @@ object LocalStore {
     }
     fun getBaseUrl(context: Context): String {
         val preferences: SharedPreferences = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
-        return preferences.getString(BASE_URL_KEY, "http://161.132.106.116/api/") ?: "http://161.132.106.116/api/"
+        return preferences.getString(BASE_URL_KEY, BuildConfig.BASE_URL) ?: BuildConfig.BASE_URL
     }
 
     fun savePrinterBluetooth(context: Context, dato: String) {

--- a/app/src/main/java/com/infomatica/inforestapp/core/RetrofitHelper.kt
+++ b/app/src/main/java/com/infomatica/inforestapp/core/RetrofitHelper.kt
@@ -13,20 +13,18 @@ import javax.inject.Singleton
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
+import com.infomatica.inforestapp.BuildConfig
 @Module
 @InstallIn(SingletonComponent::class)
 object RetrofitHelper {
     // Método para obtener Retrofit con la configuración de OkHttpClient incluida
     @Singleton
     fun getRetrofitInstance(context: Context): Retrofit {
-        var baseUrl: String
-        try {
-            baseUrl = LocalStore.getBaseUrl(context)
+        val baseUrl: String = try {
+            LocalStore.getBaseUrl(context)
         } catch (ex: Exception) {
-            baseUrl = "http://161.132.106.116/api/"
+            BuildConfig.BASE_URL
         }
-
-        //baseUrl = "http://161.132.106.116/api/"
 
         val okHttpClient = createOkHttpClient()
         return Retrofit.Builder()

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+BASE_URL=http://161.132.106.116/api/


### PR DESCRIPTION
## Summary
- expose BASE_URL property in `gradle.properties`
- pass that property to BuildConfig via build.gradle
- enable BuildConfig generation
- read BASE_URL from BuildConfig in LocalStore and RetrofitHelper

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455380d364832a9ae7633b32673cfc